### PR TITLE
Update for Ruby 3.3-ish

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,21 @@ Intro
 -----
 
 Snow-Data is a simple gem for dealing with memory and defining structs in a
-C-like way. Incidentally, it's also hideously unsafe, so everything is tainted
-by default. You'll thank me for this later, even if almost every operation does
-bounds-checking where possible to ensure you're not being a horrible person.
+C-like way. It's also hideously unsafe, so everything is tainted by default.
 
 For more information on usage, see the rdoc documentation for Snow::Memory
-and Snow::CStruct, as it explains the important things. Like CStructs. And how
-to talk to people. Ok, it can't help you with that.
-
-_ALLONS-Y!_
-
+and Snow::CStruct, as it should explain most of the important things.
 
 Example
 -------
 
-For those wanting a quick-ish example of using snow-data, I'll include one here
-showing you how you might define a few structs, including a Vec3, Vec2, Color,
-and Vertex and working with those.
+For those wanting a quick-ish example of using snow-data, the following example
+shows how to define a few structs. These are a Vec3, Vec2, Color, and Vertex,
+which may be common in game code.
 
-Bear in mind that, down the road, it will also be possible to assign snow-math
-types to these as well (provided they use the same underlying types), though I
-wouldn't use this for defining data types for anything other than transit to
-another API that expects its data in a format like this.
-
-How you use it, ultimately, is really up to you.
+In practice, this tends not to be highly useful except for interacting with
+some APIs over FFI, such as OpenGL. That said, if it happens to be useful,
+all the better.
 
     #!/usr/bin/env ruby -w
 
@@ -42,11 +33,12 @@ How you use it, ultimately, is really up to you.
     # it helps to illustrate that you can specify alignment).
     Vec3   = Snow::CStruct[:Vec3, 'x: float :4; y: float :4; z: float :4']
     Vec2   = Snow::CStruct[:Vec2, 'x: float :4; y: float :4']
+
     # ui8 is shorthand for uint8_t -- you can write either, and the documentation
     # for CStruct::new explains the short- and long-form names for each primitive
     # type provided by Snow-Data. Further, CStructs defined with a name, as with
     # Vec3, Vec2, and Color, have getters and setters defined in the Memory class
-    # and are usable as member types, as I'll show below.
+    # and are usable as member types (see below).
     Color  = Snow::CStruct[:Color, 'r: ui8; g: ui8; b: ui8; a: ui8']
 
     # Define a vertex type whose members are all also 4-byte aligned. The vertex
@@ -69,7 +61,7 @@ How you use it, ultimately, is really up to you.
       VERTEX_DESCRIPTION
     end
 
-    # So let's create a vertex.
+    # Now create a vertex:
     a_vertex = Vertex.new { |v|
       v.position      = Vec3.new { |p| p.x = 1; p.y = 2; p.z = 3 }
       v.normal        = Vec3.new { |n| n.x = 0.707107; n.y = 0; n.z = 0.707107 }
@@ -83,7 +75,7 @@ How you use it, ultimately, is really up to you.
 
     puts "Our vertex:\n#{stringify_vertex a_vertex}"
 
-    # For kicks, let's create an array.
+    # Create an array of 64 vertices:
     some_vertices = Vertex[64]
 
     # And set all vertices to the above vertex.

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -5,9 +5,6 @@
 
 require 'mkmf'
 
-# Compile as C99
-$CFLAGS += " -std=c99 -Wall -pedantic"
-
 OptKVPair = Struct.new(:key, :value)
 
 option_mappings = {
@@ -53,7 +50,7 @@ else
 end
 
 $CFLAGS += ' -DSD_ALLOW_ALLOCA' if options[:allow_alloca]
-$CFLAGS += ' -DSD_SD_WARN_ON_IMPLICIT_COPY_SIZE' if options[:warn_implicit_size]
+$CFLAGS += ' -DSD_WARN_ON_IMPLICIT_COPY_SIZE' if options[:warn_implicit_size]
 $CFLAGS += ' -DSD_WARN_ON_NO_BYTESIZE_METHOD' if options[:warn_no_bytesize]
 $CFLAGS += ' -DSD_VERBOSE_COPY_LOG' if options[:debug_memory_copy]
 $CFLAGS += ' -DSD_VERBOSE_MALLOC_LOG' if options[:debug_allocations]

--- a/ext/snow-data/snow-data.c
+++ b/ext/snow-data/snow-data.c
@@ -5,6 +5,7 @@
 */
 
 #include "ruby.h"
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -1668,7 +1669,9 @@ static VALUE sd_memory_copy(int argc, VALUE *argv, VALUE self)
   size_t destination_offset;
   size_t byte_size;
   size_t self_byte_size;
+  #if defined(SD_WARN_ON_NO_BYTESIZE_METHOD) || defined(SD_WARN_ON_IMPLICIT_COPY_SIZE)
   int source_is_data = 0;
+  #endif
 
   sd_check_null_block(self);
   rb_check_frozen(self);
@@ -1691,11 +1694,13 @@ static VALUE sd_memory_copy(int argc, VALUE *argv, VALUE self)
     }
   }
 
-  if (RTEST(rb_obj_is_kind_of(sd_source, rb_cData))) {
+  if (RTEST(rb_obj_is_kind_of(sd_source, rb_cObject))) {
     /* Otherwise extract a pointer from the object if it's a Data object */
     const struct RData *source_data = RDATA(sd_source);
     source_pointer = ((const uint8_t *)source_data->data);
+    #if defined(SD_WARN_ON_NO_BYTESIZE_METHOD) || defined(SD_WARN_ON_IMPLICIT_COPY_SIZE)
     source_is_data = 1;
+    #endif
   } else if (RTEST(rb_obj_is_kind_of(sd_source, rb_cNumeric))) {
     /* Otherwise, if it's a Numeric, try to convert what is assumed to be an
       address to a pointer */
@@ -1890,7 +1895,8 @@ static VALUE sd_align_size(int argc, VALUE *argv, VALUE self)
 void Init_snowdata_bindings(void)
 {
   VALUE sd_snow_module  = rb_define_module("Snow");
-  VALUE sd_memory_klass = rb_define_class_under(sd_snow_module, "Memory", rb_cData);
+  VALUE sd_memory_klass = rb_define_class_under(sd_snow_module, "Memory", rb_cObject);
+  rb_undef_alloc_func(sd_memory_klass);
 
   kSD_IVAR_BYTESIZE     = rb_intern("@__bytesize__");
   kSD_IVAR_ALIGNMENT    = rb_intern("@__alignment__");

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+[positional-arguments]
+install *args: build
+    gem uninstall snow-data --version "$(just version)"
+    gem install "$@" "snow-data-$(just version).gem"
+
+build:
+    rm -fv "snow-data-$(just version).gem"
+    gem build
+
+version:
+    #!/usr/bin/env ruby
+    require File.expand_path('lib/snow-data/version.rb', Dir.pwd)
+    $stdout.write Snow::SNOW_DATA_VERSION

--- a/lib/snow-data/version.rb
+++ b/lib/snow-data/version.rb
@@ -7,6 +7,6 @@ module Snow
   #
   # The snow-data version string.
   #
-  SNOW_DATA_VERSION = '1.3.1'.freeze
+  SNOW_DATA_VERSION = '1.4.0'.freeze
 
 end

--- a/snow-data.gemspec
+++ b/snow-data.gemspec
@@ -7,7 +7,7 @@ require File.expand_path('../lib/snow-data/version.rb', __FILE__)
 Gem::Specification.new { |s|
   s.name        = 'snow-data'
   s.version     = Snow::SNOW_DATA_VERSION
-  s.date        = '2013-07-20'
+  s.date        = '2025-04-17'
   s.summary     = "Snow-Data: for working with memory like you've got nothing to lose."
   s.description = <<-EOS
 Snow-Data is a gem for allocating memory and working with existing blocks of
@@ -16,14 +16,13 @@ also provides functionality for defining C-struct classes, including those with
 other structs as members.
   EOS
   s.authors     = [ 'Noel Raymond Cower' ]
-  s.email       = 'ncower@gmail.com'
+  s.email       = 'ncower@nil.dev'
   s.files       = Dir.glob('lib/**/*.rb') +
                   Dir.glob('ext/**/*.{c,h,rb}') +
                   [ 'COPYING', 'README.md' ]
   s.extensions << 'ext/extconf.rb'
   s.homepage    = 'https://github.com/nilium/ruby-snowdata'
-  s.license     = 'Simplified BSD'
-  s.has_rdoc    = true
+  s.license     = 'BSD-2-Clause'
   s.extra_rdoc_files = [
       'ext/snow-data/snow-data.c',
       'README.md',
@@ -33,5 +32,5 @@ other structs as members.
                     '--main' << 'README.md' <<
                     '--markup=markdown' <<
                     '--line-numbers'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 3.3.0'
 }


### PR DESCRIPTION
Fix up a few things so this builds on my machine these days using Ruby 3.3.4. Removes the C99 spec and warning flags (I'm no longer willing to entertain having those on in projects).

Also fix a long-missed typo in the definition of
`SD_WARN_ON_IMPLICIT_COPY_SIZE`, which previously had an extra `SD_` at the start of it.

Also also, make the README more boring and hopefully less cringe.

No plans to tag/publish this until I know it at least works on both my Linux/macOS systems.